### PR TITLE
fix typo toturial -> tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Travis](https://img.shields.io/travis/rust-lang/rust.svg)]()
 
 [Installation](doc/install.md) |
-[Toturial](doc/toturial.md) |
+[Tutorial](doc/toturial.md) |
 [RoadMap](doc/roadmap.md) |
 [Release Notes](doc/news.md) 
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1,4 +1,4 @@
-## Toturial
+## Tutorial
 
 Before using xLearn, make sure that you have already build it successfully. See the page [install.md][1] for installing xLearn.
  


### PR DESCRIPTION
###  fix typo ` toturial` -> ` tutorial `