### PR TITLE
Changed local variable name to not be in conflict with class member.

### DIFF
--- a/src/data/data_structure.h
+++ b/src/data/data_structure.h
@@ -221,9 +221,9 @@ struct DMatrix {
     this->row.resize(row_length, nullptr);
     // Copy row
     for (index_t i = 0; i < row_length; ++i) {
-      SparseRow* row = matrix->row[i];
-      for (SparseRow::iterator iter = row->begin();
-           iter != row->end(); ++iter) {
+      SparseRow* rowc = matrix->row[i];
+      for (SparseRow::iterator iter = rowc->begin();
+           iter != rowc->end(); ++iter) {
         this->AddNode(i, 
                 iter->feat_id, 
                 iter->feat_val, 

--- a/src/loss/metric.h
+++ b/src/loss/metric.h
@@ -554,7 +554,7 @@ class AUCMetric : public Metric {
       positive_sum += all_positive_number_[i];
       negative_sum += all_negative_number_[i];
       auc += (pre_positive_sum + positive_sum) * 
-             all_negative_number_[i] * 1.0 / 2;
+             (double)(all_negative_number_[i]) * 1.0 / 2;
     }
     positivesum_dot_negativesum = positive_sum * negative_sum;
     auc_res = auc / (positivesum_dot_negativesum);

--- a/src/reader/file_splitor.cc
+++ b/src/reader/file_splitor.cc
@@ -85,6 +85,9 @@ void FileSpliter::split(const std::string& filename, int num_blocks) {
         average_block_size + (next_block_size - real_file_size);
     offset += real_file_size;
   }
+  delete *file_ptr_write;
+  delete file_ptr_write;
+  delete file_desc_write;
   munmap(map_ptr_read, file_size);
 }
 


### PR DESCRIPTION
Implicitly casted int to double to avoid variable overflow.
Memory leak fixed, two variables were not released.