### PR TITLE
Fix lack of <algorithm> dependency when compiling

### DIFF
--- a/src/data/data_structure.h
+++ b/src/data/data_structure.h
@@ -26,6 +26,7 @@ This file defines the basic data structures used by xLearn.
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
+#include <algorithm>
 
 #include "src/base/common.h"
 #include "src/base/file_util.h"


### PR DESCRIPTION
Fix problem below when compiling:

In file included from xlearn/src/data/model_parameters.h:31:0,
                 from xlearn/src/data/model_parameters.cc:23:
xlearn/src/data/data_structure.h: In member function ‘void xLearn::DMatrix::Compress(std::vector<unsigned int>&)’:
xlearn/src/data/data_structure.h:293:5: error: ‘sort’ is not a member of ‘std’
     std::sort(begin(feature_list), end(feature_list));
     ^
make[2]: *** [src/data/CMakeFiles/data.dir/model_parameters.cc.o] Error 1
make[1]: *** [src/data/CMakeFiles/data.dir/all] Error 2
make: *** [all] Error 2