### PR TITLE
fix duplicate installation in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,10 +8,7 @@ make
 # install python package
 
 cd python-package
-if command -v python2; then
-    python2 setup.py install
+if command -v python; then
+    python setup.py install
 fi
 
-if command -v python3; then
-    python3 setup.py install
-fi


### PR DESCRIPTION
- previously build.sh will try to install xlearn to all versions of python in a machine, which is quite unreasonable. This commit fix it and now build.sh only install xlearn to the current command line env's default python