### PR TITLE
Accept huge number of features

### DIFF
--- a/src/data/data_structure.h
+++ b/src/data/data_structure.h
@@ -39,10 +39,10 @@ namespace xLearn {
 typedef float real_t;
 
 //------------------------------------------------------------------------------
-// We use 32-bits unsigned integer to store the index 
+// We use 64-bits unsigned integer to store the index 
 // of the feature and the model parameters.
 //------------------------------------------------------------------------------
-typedef uint32 index_t;
+typedef uint64 index_t;
 
 //------------------------------------------------------------------------------
 // Mapping sparse feature to dense feature. Used by distributed computation.


### PR DESCRIPTION
As comments below says, when we use ffm, `param_num_v_` consists of `num_feat * num_field * num_K * 2`.

src/data/model_parameters.h

``` c
/* Size of the latent factor. 
We store both the model parameters and the gradient 
cache for adagrad in param_v_. 
For linear function, param_num_v = 0
For fm function, param_num_v_ = num_feat * num_K * 2
For ffm funtion, param_num_v_ = num_feat * num_field * num_K * 2  */
index_t  param_num_v_;
```

Since the type of `param_num_v_` is index_t(uint32),
we can't use ffm with a huge variety of features.
In my use case, `num_feat` is 2^24 and `num_field` is 27.

It's nice for me to accept more features.