### PR TITLE
Fix memory leak in InmemReader

### DIFF
--- a/src/reader/reader.cc
+++ b/src/reader/reader.cc
@@ -247,7 +247,8 @@ void InmemReader::init_from_txt() {
     std::string bin_file = filename_ + ".bin";
     data_buf_.Serialize(bin_file);
   }
-  delete [] block_;
+  free(block_);
+  block_ = nullptr;
   Close(file);
 }
 

--- a/src/reader/reader.h
+++ b/src/reader/reader.h
@@ -180,7 +180,9 @@ class InmemReader : public Reader {
  public:
   // Constructor and Destructor
   InmemReader() : pos_(0) { }
-  ~InmemReader() { }
+  ~InmemReader() {
+    Clear();
+  }
 
   // Pre-load all the data into memory buffer.
   virtual void Initialize(const std::string& filename);
@@ -195,9 +197,8 @@ class InmemReader : public Reader {
   // Free the memory of data matrix.
   virtual void Clear() {
     data_buf_.Reset();
-    data_samples_.Reset();
     if (block_ != nullptr) {
-      delete [] block_;
+      free(block_);
     }
   }
 


### PR DESCRIPTION
xLearn::InmemReader suffers from the problem of memory leak, which will affect the performance of training/prediction on large dataset.