### PR TITLE
Added a search path in the build directory

### DIFF
--- a/python-package/xlearn/libpath.py
+++ b/python-package/xlearn/libpath.py
@@ -34,6 +34,7 @@ def find_lib_path():
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     # make pythonpack hack: copy this directory one level upper for setup.py
     dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
+                os.path.join(curr_path, '../../build/lib/'),
                 os.path.join(curr_path, './lib/'),
                 os.path.join(sys.prefix, 'xlearn')]
     if sys.platform == 'win32':


### PR DESCRIPTION
Fix the bug that cannot find xlearn Library in the candidate path when compiling and installing python-packages from source code.