### PR TITLE
Fix spelling error in type of loss_func

### DIFF
--- a/src/loss/loss_test.cc
+++ b/src/loss/loss_test.cc
@@ -62,7 +62,7 @@ class LossTest : public ::testing::Test {
   virtual void SetUp() {
     param.learning_rate = 0.1;
     param.regu_lambda = 0;
-    param.loss_func = "sqaured";
+    param.loss_func = "squared";
     param.score_func = "linear";
     param.num_feature = 3;
     param.num_field = 3;


### PR DESCRIPTION
Hi, I fix a spelling error in type of  loss_func, it should be **squared**, not **sqaured**.