### PR TITLE
fix scipy version for python 2.7

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -40,8 +40,9 @@ setup(name='xlearn',
       # this is the golden line
       include_package_data=True,
       install_requires=[
-            "numpy", 
-            "scipy"
+            'numpy', 
+            'scipy<1.3.0; python_version<"3"',
+            'scipy>=1.3.0; python_version>="3"'
       ],
       data_files=[('xlearn', LIB_PATH)],
       license='Apache-2.0',

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -121,8 +121,9 @@ if __name__ == "__main__":
           # this is the golden line
           include_package_data=True,
           install_requires=[
-              "numpy", 
-              "scipy"
+              'numpy', 
+              'scipy<1.3.0; python_version<"3"',
+              'scipy>=1.3.0; python_version>="3"'
           ],
           # move data to MANIFEST.in
           license='Apache-2.0',


### PR DESCRIPTION
In case if we install `xlearn` for Python 2.7, following error raised:

```
Installed /usr/local/lib/python2.7/dist-packages/xlearn-0.4.3-py2.7.egg
Processing dependencies for xlearn==0.4.3
Searching for scipy
Reading https://pypi.org/simple/scipy/
Downloading https://files.pythonhosted.org/packages/df/20/2f147945396fa74b467d696e42aa55eb603d166490a8ebe4d79e54c793df/scipy-1.3.2.tar.gz#sha256=a03939b431994289f39373c57bbe452974a7da724ae7f9620a1beee575434da4
Best match: scipy 1.3.2
Processing scipy-1.3.2.tar.gz
Writing /tmp/easy_install-TqDu0w/scipy-1.3.2/setup.cfg
Running scipy-1.3.2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-TqDu0w/scipy-1.3.2/egg-dist-tmp-0czLTK
Traceback (most recent call last):
  File "setup.py", line 49, in <module>
    url='https://github.com/aksnzhy/xlearn')
  File "/usr/local/lib/python2.7/dist-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 418, in run
    self.easy_install(spec, not self.no_deps)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 660, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 707, in install_item
    self.process_distribution(spec, dist, deps)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 752, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 782, in resolve
    replace_conflicting=replace_conflicting
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1065, in best_match
    return self.obtain(req, installer)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1077, in obtain
    return installer(requirement)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 679, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 705, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 890, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1158, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/command/easy_install.py", line 1144, in run_setup
    run_setup(setup_script, args)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 253, in run_setup
    raise
  File "/usr/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/usr/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 166, in save_modules
    saved_exc.resume()
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 141, in resume
    six.reraise(type, exc, self._tb)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 154, in save_modules
    yield saved
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 195, in setup_context
    yield
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 250, in run_setup
    _execfile(setup_script, ns)
  File "/usr/local/lib/python2.7/dist-packages/setuptools/sandbox.py", line 45, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-TqDu0w/scipy-1.3.2/setup.py", line 31, in <module>
    
RuntimeError: Python version >= 3.5 required.
```
Because by current settings it takes latest version of `scipy` which isn't available for `Python 2.7.`
I've added rule which will take last available `scipy` version for Python 2.7, because since `scipy 1.3.0` usage python 2.7 for this library was depricated.