### PR TITLE
fix the terminate error - std::logic_error issue on some OS environme…

### DIFF
--- a/src/solver/solver.cc
+++ b/src/solver/solver.cc
@@ -173,7 +173,7 @@ void Solver::checker(HyperParam& hyper_param) {
 
 // Initialize log file
 void Solver::init_log() {
-  std::string prefix = get_log_file(hyper_param_.log_file);
+  std::string prefix = hyper_param_.log_file;
   if (hyper_param_.is_train) {
     prefix += "_train";
   } else {


### PR DESCRIPTION
Check the issue #311 
some error cases when installed by pip in latest ubuntu(or CentOS). because of c compiler version issue, the `init_log()`'s parameter is empty. maybe specify the parameter is needed.